### PR TITLE
Add authnix.sh with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # authnix
-Script that setup netrc file for nix, so you can use non public repos
+`authnix.sh` is script that setup netrc file for nix. This allows you to use private/internal github repos as sources for nix. 
+
+## Use
+To use this script you need a [GitHub personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with access to the repos you want
+to use. 
+
+Then you run then following command in you terminal:
+```
+bash <(curl -sL https://raw.githubusercontent.com/bkkp/authnix/main/authnix.sh) <your-github-token>
+```
+where you subsitue `<your-github-token>` with your GitHub token. If nix's netrc file is protected you will be ask for sudo password.
+
+## In Github Action
+To use is in Github Actions you can use the following step:
+```
+- name: Setup nix netrc file with authnix
+  run: bash <(curl -sL https://raw.githubusercontent.com/bkkp/authnix/main/authnix.sh)
+  env:
+    GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}
+```
+where is a sercret in your repo with your github access token.
+
+### Alternativ
+1. Set GITHUB_TOKEN as env.
+```
+export GITHUB_TOKEN=<your-github-token>
+bash <(curl -sL https://raw.githubusercontent.com/bkkp/authnix/main/authnix.sh) <your-github-token>
+```
+
+2. Temp variable
+```
+GITHUB_TOKEN=<your-github-token> bash <(curl -sL https://raw.githubusercontent.com/bkkp/authnix/main/authnix.sh) <your-github-token>
+```

--- a/authnix.sh
+++ b/authnix.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+if [[ $1 != "" ]]; then
+  TOKEN=$1
+elif [[ $GITHUB_TOKEN != "" ]]; then
+  TOKEN=$GITHUB_TOKEN
+else
+  echo "ERROR: Token not given. Give it as an argument or set env GITHUB_TOKEN."
+  exit 1
+fi
+
+NIX_NETRC=$(nix show-config | sed -n 's/.*netrc-file = //p')
+
+if [[ -z $NIX_NETRC ]]; then
+  echo "ERROR: Can not find nix netrc file locations in config. Is nix installed?"
+  exit 1
+fi
+
+cat <<EOF | sudo tee -a $NIX_NETRC > /dev/null
+machine github.com
+  login token
+  password $TOKEN
+
+EOF


### PR DESCRIPTION
authnix.sh is a script to setup netrc file for nix.
This make it possible to use private and internal github
repos as sources for nix.