### PR TITLE
Add api.github.com to netrc

### DIFF
--- a/authnix.sh
+++ b/authnix.sh
@@ -22,4 +22,8 @@ machine github.com
   login token
   password $TOKEN
 
+machine api.github.com
+  login token
+  password $TOKEN
+
 EOF


### PR DESCRIPTION
When using flake-compat with "old" nix without flakes and where
access-token config option is not available. Download from github
go through `api.github.com`